### PR TITLE
New version-dependent charts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 /out/
 /target/
 /.idea/
+/.settings/
 
 # Files
 *.iml
+.classpath
+.project

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>dev.walshy</groupId>
@@ -27,15 +27,15 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.github.TheBusyBiscuit</groupId>
-            <artifactId>Slimefun4</artifactId>
-            <version>c2b0121a07</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
             <version>1.16.1-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.TheBusyBiscuit</groupId>
+            <artifactId>Slimefun4</artifactId>
+            <version>9c006f6897</version>
             <scope>provided</scope>
         </dependency>
 
@@ -50,6 +50,7 @@
         <defaultGoal>clean package</defaultGoal>
         <finalName>${project.artifactId}</finalName>
         <sourceDirectory>src/main/java</sourceDirectory>
+        
         <resources>
             <resource>
                 <targetPath>.</targetPath>
@@ -60,6 +61,7 @@
                 </includes>
             </resource>
         </resources>
+        
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -70,6 +72,7 @@
                     <target>1.8</target>
                 </configuration>
             </plugin>
+            
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
@@ -82,15 +85,18 @@
                         </relocation>
                     </relocations>
                 </configuration>
+                
                 <executions>
                     <execution>
                         <goals>
                             <goal>shade</goal>
                         </goals>
+                        
                         <configuration>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
-                            <transformers>`
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                            <transformers>
+                                <transformer
+                                    implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <manifestEntries>
                                         <Implementation-Version>${project.version}</Implementation-Version>
                                     </manifestEntries>

--- a/src/main/java/dev/walshy/sfmetrics/MetricsModule.java
+++ b/src/main/java/dev/walshy/sfmetrics/MetricsModule.java
@@ -28,7 +28,7 @@ public class MetricsModule {
     public static final String VERSION = MetricsModule.class.getPackage().getImplementationVersion();
     public static final int PLUGIN_ID = 4574;
 
-    private static SlimefunBranch branch;
+    private static SlimefunBranch branch = SlimefunBranch.UNKNOWN;
     private static int slimefunVersion = -1;
     private static int charts = 0;
 

--- a/src/main/java/dev/walshy/sfmetrics/MetricsModule.java
+++ b/src/main/java/dev/walshy/sfmetrics/MetricsModule.java
@@ -5,7 +5,7 @@ import dev.walshy.sfmetrics.charts.AutoUpdaterChart;
 import dev.walshy.sfmetrics.charts.CommandChart;
 import dev.walshy.sfmetrics.charts.CompatibilityModeChart;
 import dev.walshy.sfmetrics.charts.GuideLayoutChart;
-import dev.walshy.sfmetrics.charts.MetricAutoUpdatesChart;
+import dev.walshy.sfmetrics.charts.MetricsAutoUpdatesChart;
 import dev.walshy.sfmetrics.charts.MetricsVersionChart;
 import dev.walshy.sfmetrics.charts.PlayerLanguageChart;
 import dev.walshy.sfmetrics.charts.ResearchesEnabledChart;
@@ -44,6 +44,6 @@ public class MetricsModule {
 
         // Metric specific
         metrics.addCustomChart(new MetricsVersionChart());
-        metrics.addCustomChart(new MetricAutoUpdatesChart());
+        metrics.addCustomChart(new MetricsAutoUpdatesChart());
     }
 }

--- a/src/main/java/dev/walshy/sfmetrics/MetricsModule.java
+++ b/src/main/java/dev/walshy/sfmetrics/MetricsModule.java
@@ -6,6 +6,7 @@ import dev.walshy.sfmetrics.charts.CommandChart;
 import dev.walshy.sfmetrics.charts.CompatibilityModeChart;
 import dev.walshy.sfmetrics.charts.GuideLayoutChart;
 import dev.walshy.sfmetrics.charts.MetricsVersionChart;
+import dev.walshy.sfmetrics.charts.NewServersChart;
 import dev.walshy.sfmetrics.charts.PlayerLanguageChart;
 import dev.walshy.sfmetrics.charts.ResearchesEnabledChart;
 import dev.walshy.sfmetrics.charts.ResourcePackChart;
@@ -18,12 +19,12 @@ import org.bstats.bukkit.Metrics;
 public class MetricsModule {
 
     public static final String VERSION = MetricsModule.class.getPackage().getImplementationVersion();
+    public static final int PLUGIN_ID = 4574;
 
     private MetricsModule() {}
 
-    @SuppressWarnings("unused")
     public static void start() {
-        Metrics metrics = new Metrics(SlimefunPlugin.instance(), 4574);
+        Metrics metrics = new Metrics(SlimefunPlugin.instance(), PLUGIN_ID);
 
         if (SlimefunPlugin.getUpdater().getBranch().isOfficial()) {
             // We really do not need this data if it is an unofficially modified build...
@@ -41,6 +42,7 @@ public class MetricsModule {
         metrics.addCustomChart(new ServerSizeChart());
         metrics.addCustomChart(new CompatibilityModeChart());
         metrics.addCustomChart(new MetricsVersionChart());
+        metrics.addCustomChart(new NewServersChart());
 
         SlimefunPlugin.instance().getLogger().info("Now running MetricsModule v" + VERSION);
     }

--- a/src/main/java/dev/walshy/sfmetrics/MetricsModule.java
+++ b/src/main/java/dev/walshy/sfmetrics/MetricsModule.java
@@ -27,41 +27,46 @@ public class MetricsModule {
     public static final String VERSION = MetricsModule.class.getPackage().getImplementationVersion();
     public static final int PLUGIN_ID = 4574;
 
+    private static SlimefunBranch branch;
+    private static int slimefunVersion = -1;
+    private static int charts = 0;
+
     private MetricsModule() {}
 
     public static void start() {
         Metrics metrics = new Metrics(SlimefunPlugin.instance(), PLUGIN_ID);
+        branch = SlimefunPlugin.getUpdater().getBranch();
+        slimefunVersion = SlimefunPlugin.getUpdater().getBuildNumber();
 
-        SlimefunPlugin.instance().getLogger().info("Now running MetricsModule build #" + VERSION);
+        addChart(metrics, AutoUpdaterChart::new);
+        addChart(metrics, ResourcePackChart::new);
+        addChart(metrics, SlimefunVersionChart::new);
+        addChart(metrics, ServerLanguageChart::new);
+        addChart(metrics, PlayerLanguageChart::new);
+        addChart(metrics, ResearchesEnabledChart::new);
+        addChart(metrics, GuideLayoutChart::new);
+        addChart(metrics, AddonsChart::new);
+        addChart(metrics, CommandChart::new);
+        addChart(metrics, ServerSizeChart::new);
+        addChart(metrics, CompatibilityModeChart::new);
+        addChart(metrics, MetricsVersionChart::new);
+        addChart(metrics, NewServersChart::new);
 
-        SlimefunBranch branch = SlimefunPlugin.getUpdater().getBranch();
-        int slimefunVersion = SlimefunPlugin.getUpdater().getBuildNumber();
-
-        addChart(metrics, branch, slimefunVersion, AutoUpdaterChart::new);
-        addChart(metrics, branch, slimefunVersion, ResourcePackChart::new);
-        addChart(metrics, branch, slimefunVersion, SlimefunVersionChart::new);
-        addChart(metrics, branch, slimefunVersion, ServerLanguageChart::new);
-        addChart(metrics, branch, slimefunVersion, PlayerLanguageChart::new);
-        addChart(metrics, branch, slimefunVersion, ResearchesEnabledChart::new);
-        addChart(metrics, branch, slimefunVersion, GuideLayoutChart::new);
-        addChart(metrics, branch, slimefunVersion, AddonsChart::new);
-        addChart(metrics, branch, slimefunVersion, CommandChart::new);
-        addChart(metrics, branch, slimefunVersion, ServerSizeChart::new);
-        addChart(metrics, branch, slimefunVersion, CompatibilityModeChart::new);
-        addChart(metrics, branch, slimefunVersion, MetricsVersionChart::new);
-        addChart(metrics, branch, slimefunVersion, NewServersChart::new);
+        SlimefunPlugin.instance().getLogger().log(Level.INFO, "Now running MetricsModule build #{0}", VERSION);
+        SlimefunPlugin.instance().getLogger().log(Level.INFO, "with a total of {0} chart(s)!", charts);
     }
 
-    private static void addChart(Metrics metrics, SlimefunBranch branch, int build, Supplier<CustomChart> constructor) {
+    private static void addChart(Metrics metrics, Supplier<CustomChart> constructor) {
         try {
             CustomChart chart = constructor.get();
 
-            if (chart instanceof VersionDependentChart && !((VersionDependentChart) chart).isCompatible(branch, build)) {
+            if (chart instanceof VersionDependentChart && !((VersionDependentChart) chart).isCompatible(branch, slimefunVersion)) {
                 // Not compatible with this Slimefun version
                 return;
             }
 
             metrics.addCustomChart(chart);
+            charts++;
         }
         catch (Exception | LinkageError x) {
             SlimefunPlugin.instance().getLogger().log(Level.WARNING, x, () -> "Failed to load a bStats chart for Metrics #" + VERSION);

--- a/src/main/java/dev/walshy/sfmetrics/MetricsModule.java
+++ b/src/main/java/dev/walshy/sfmetrics/MetricsModule.java
@@ -52,7 +52,7 @@ public class MetricsModule {
         addChart(metrics, CompatibilityModeChart::new);
         addChart(metrics, MetricsVersionChart::new);
         addChart(metrics, NewServersChart::new);
-        metrics.addCustomChart(new MetricsAutoUpdatesChart());
+        addChart(metrics, MetricsAutoUpdatesChart::new);
       
         SlimefunPlugin.instance().getLogger().log(Level.INFO, "Now running MetricsModule build #{0}", VERSION);
         SlimefunPlugin.instance().getLogger().log(Level.INFO, "with a total of {0} chart(s)!", charts);

--- a/src/main/java/dev/walshy/sfmetrics/MetricsModule.java
+++ b/src/main/java/dev/walshy/sfmetrics/MetricsModule.java
@@ -53,7 +53,7 @@ public class MetricsModule {
         addChart(metrics, MetricsVersionChart::new);
         addChart(metrics, NewServersChart::new);
         addChart(metrics, MetricsAutoUpdatesChart::new);
-      
+
         SlimefunPlugin.instance().getLogger().log(Level.INFO, "Now running MetricsModule build #{0}", VERSION);
         SlimefunPlugin.instance().getLogger().log(Level.INFO, "with a total of {0} chart(s)!", charts);
     }

--- a/src/main/java/dev/walshy/sfmetrics/MetricsModule.java
+++ b/src/main/java/dev/walshy/sfmetrics/MetricsModule.java
@@ -5,6 +5,7 @@ import dev.walshy.sfmetrics.charts.AutoUpdaterChart;
 import dev.walshy.sfmetrics.charts.CommandChart;
 import dev.walshy.sfmetrics.charts.CompatibilityModeChart;
 import dev.walshy.sfmetrics.charts.GuideLayoutChart;
+import dev.walshy.sfmetrics.charts.MetricAutoUpdatesChart;
 import dev.walshy.sfmetrics.charts.MetricsVersionChart;
 import dev.walshy.sfmetrics.charts.PlayerLanguageChart;
 import dev.walshy.sfmetrics.charts.ResearchesEnabledChart;
@@ -40,8 +41,9 @@ public class MetricsModule {
         metrics.addCustomChart(new CommandChart());
         metrics.addCustomChart(new ServerSizeChart());
         metrics.addCustomChart(new CompatibilityModeChart());
-        metrics.addCustomChart(new MetricsVersionChart());
 
-        SlimefunPlugin.instance().getLogger().info("Now running MetricsModule v" + VERSION);
+        // Metric specific
+        metrics.addCustomChart(new MetricsVersionChart());
+        metrics.addCustomChart(new MetricAutoUpdatesChart());
     }
 }

--- a/src/main/java/dev/walshy/sfmetrics/VersionDependentChart.java
+++ b/src/main/java/dev/walshy/sfmetrics/VersionDependentChart.java
@@ -1,0 +1,19 @@
+package dev.walshy.sfmetrics;
+
+import org.bstats.bukkit.Metrics.CustomChart;
+
+import io.github.thebusybiscuit.slimefun4.api.SlimefunBranch;
+
+/**
+ * This {@link FunctionalInterface} marks a {@link CustomChart} as dependent on specific
+ * versions of Slimefun.
+ * 
+ * @author TheBusyBiscuit
+ *
+ */
+@FunctionalInterface
+public interface VersionDependentChart {
+
+    boolean isCompatible(SlimefunBranch branch, int build);
+
+}

--- a/src/main/java/dev/walshy/sfmetrics/charts/AddonsChart.java
+++ b/src/main/java/dev/walshy/sfmetrics/charts/AddonsChart.java
@@ -1,12 +1,24 @@
 package dev.walshy.sfmetrics.charts;
 
-import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
-import org.bstats.bukkit.Metrics.AdvancedPie;
-import org.bukkit.plugin.Plugin;
-
 import java.util.HashMap;
 import java.util.Map;
 
+import org.bstats.bukkit.Metrics.AdvancedPie;
+import org.bukkit.Server;
+import org.bukkit.plugin.Plugin;
+
+import io.github.thebusybiscuit.slimefun4.api.SlimefunAddon;
+import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
+
+/**
+ * This {@link AdvancedPie} shows us what {@link SlimefunAddon Addons} are installed on the
+ * {@link Server}.
+ * 
+ * This allows us to see what Addons are popular than others in one overview.
+ * 
+ * @author TheBusyBiscuit
+ *
+ */
 public class AddonsChart extends AdvancedPie {
 
     public AddonsChart() {

--- a/src/main/java/dev/walshy/sfmetrics/charts/AutoUpdaterChart.java
+++ b/src/main/java/dev/walshy/sfmetrics/charts/AutoUpdaterChart.java
@@ -3,6 +3,8 @@ package dev.walshy.sfmetrics.charts;
 import org.bstats.bukkit.Metrics.SimplePie;
 import org.bukkit.Server;
 
+import dev.walshy.sfmetrics.VersionDependentChart;
+import io.github.thebusybiscuit.slimefun4.api.SlimefunBranch;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 
 /**
@@ -14,13 +16,19 @@ import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
  * @author TheBusyBiscuit
  *
  */
-public class AutoUpdaterChart extends SimplePie {
+public class AutoUpdaterChart extends SimplePie implements VersionDependentChart {
 
     public AutoUpdaterChart() {
         super("auto_updates", () -> {
             boolean enabled = SlimefunPlugin.getUpdater().isEnabled();
             return enabled ? "enabled" : "disabled";
         });
+    }
+
+    @Override
+    public boolean isCompatible(SlimefunBranch branch, int build) {
+        // Auto updates are only meaningful to us for official builds
+        return branch.isOfficial();
     }
 
 }

--- a/src/main/java/dev/walshy/sfmetrics/charts/AutoUpdaterChart.java
+++ b/src/main/java/dev/walshy/sfmetrics/charts/AutoUpdaterChart.java
@@ -1,8 +1,19 @@
 package dev.walshy.sfmetrics.charts;
 
-import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import org.bstats.bukkit.Metrics.SimplePie;
+import org.bukkit.Server;
 
+import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
+
+/**
+ * This {@link SimplePie} shows us how many {@link Server Servers} have enabled or disabled
+ * automatic updates.
+ * 
+ * This allows us to understand how many {@link Server Servers} opted out of automatic updates.
+ * 
+ * @author TheBusyBiscuit
+ *
+ */
 public class AutoUpdaterChart extends SimplePie {
 
     public AutoUpdaterChart() {

--- a/src/main/java/dev/walshy/sfmetrics/charts/CommandChart.java
+++ b/src/main/java/dev/walshy/sfmetrics/charts/CommandChart.java
@@ -1,12 +1,21 @@
 package dev.walshy.sfmetrics.charts;
 
-import io.github.thebusybiscuit.slimefun4.core.commands.SubCommand;
-import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
-import org.bstats.bukkit.Metrics.AdvancedPie;
-
 import java.util.HashMap;
 import java.util.Map;
 
+import org.bstats.bukkit.Metrics.AdvancedPie;
+
+import io.github.thebusybiscuit.slimefun4.core.commands.SubCommand;
+import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
+
+/**
+ * This {@link AdvancedPie} shows us what {@link SubCommand} of Slimefun is run very often.
+ * 
+ * This allows us to see what {@link SubCommand commands} are used more often than others.
+ * 
+ * @author TheBusyBiscuit
+ *
+ */
 public class CommandChart extends AdvancedPie {
 
     public CommandChart() {

--- a/src/main/java/dev/walshy/sfmetrics/charts/CompatibilityModeChart.java
+++ b/src/main/java/dev/walshy/sfmetrics/charts/CompatibilityModeChart.java
@@ -1,8 +1,17 @@
 package dev.walshy.sfmetrics.charts;
 
-import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import org.bstats.bukkit.Metrics.SimplePie;
+import org.bukkit.Server;
 
+import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
+
+/**
+ * This {@link SimplePie} shows us how many {@link Server Servers} have enabled or disabled
+ * backwards-compatibility.
+ * 
+ * @author TheBusyBiscuit
+ *
+ */
 public class CompatibilityModeChart extends SimplePie {
 
     public CompatibilityModeChart() {

--- a/src/main/java/dev/walshy/sfmetrics/charts/GuideLayoutChart.java
+++ b/src/main/java/dev/walshy/sfmetrics/charts/GuideLayoutChart.java
@@ -1,8 +1,18 @@
 package dev.walshy.sfmetrics.charts;
 
-import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import org.bstats.bukkit.Metrics.SimplePie;
+import org.bukkit.Server;
 
+import io.github.thebusybiscuit.slimefun4.core.guide.SlimefunGuideLayout;
+import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
+
+/**
+ * This {@link SimplePie} allows us to see what {@link Server Servers} tend to set as
+ * their default {@link SlimefunGuideLayout}.
+ * 
+ * @author TheBusyBiscuit
+ *
+ */
 public class GuideLayoutChart extends SimplePie {
 
     public GuideLayoutChart() {

--- a/src/main/java/dev/walshy/sfmetrics/charts/MetricAutoUpdatesChart.java
+++ b/src/main/java/dev/walshy/sfmetrics/charts/MetricAutoUpdatesChart.java
@@ -1,0 +1,14 @@
+package dev.walshy.sfmetrics.charts;
+
+import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
+import org.bstats.bukkit.Metrics;
+
+public class MetricAutoUpdatesChart extends Metrics.SimplePie {
+
+    public MetricAutoUpdatesChart() {
+        super("metrics_auto_updates", () -> {
+            boolean enabled = SlimefunPlugin.getMetricsService().hasAutoUpdates();
+            return enabled ? "enabled" : "disabled";
+        });
+    }
+}

--- a/src/main/java/dev/walshy/sfmetrics/charts/MetricsAutoUpdatesChart.java
+++ b/src/main/java/dev/walshy/sfmetrics/charts/MetricsAutoUpdatesChart.java
@@ -3,9 +3,9 @@ package dev.walshy.sfmetrics.charts;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import org.bstats.bukkit.Metrics;
 
-public class MetricAutoUpdatesChart extends Metrics.SimplePie {
+public class MetricsAutoUpdatesChart extends Metrics.SimplePie {
 
-    public MetricAutoUpdatesChart() {
+    public MetricsAutoUpdatesChart() {
         super("metrics_auto_updates", () -> {
             boolean enabled = SlimefunPlugin.getMetricsService().hasAutoUpdates();
             return enabled ? "enabled" : "disabled";

--- a/src/main/java/dev/walshy/sfmetrics/charts/MetricsAutoUpdatesChart.java
+++ b/src/main/java/dev/walshy/sfmetrics/charts/MetricsAutoUpdatesChart.java
@@ -1,14 +1,39 @@
 package dev.walshy.sfmetrics.charts;
 
-import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
-import org.bstats.bukkit.Metrics;
+import org.bstats.bukkit.Metrics.SimplePie;
+import org.bukkit.Server;
 
-public class MetricsAutoUpdatesChart extends Metrics.SimplePie {
+import dev.walshy.sfmetrics.MetricsModule;
+import dev.walshy.sfmetrics.VersionDependentChart;
+import io.github.thebusybiscuit.slimefun4.api.SlimefunBranch;
+import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
+
+/**
+ * This {@link SimplePie} shows us whether a {@link Server} has enabled or disabled
+ * automatic updates for our {@link MetricsModule}.
+ * 
+ * @author Walshy
+ *
+ */
+public class MetricsAutoUpdatesChart extends SimplePie implements VersionDependentChart {
 
     public MetricsAutoUpdatesChart() {
         super("metrics_auto_updates", () -> {
             boolean enabled = SlimefunPlugin.getMetricsService().hasAutoUpdates();
             return enabled ? "enabled" : "disabled";
         });
+    }
+
+    @Override
+    public boolean isCompatible(SlimefunBranch branch, int build) {
+        if (branch == SlimefunBranch.DEVELOPMENT) {
+            return build >= 600;
+        }
+        else if (branch == SlimefunBranch.STABLE) {
+            return build >= 15;
+        }
+        else {
+            return false;
+        }
     }
 }

--- a/src/main/java/dev/walshy/sfmetrics/charts/MetricsVersionChart.java
+++ b/src/main/java/dev/walshy/sfmetrics/charts/MetricsVersionChart.java
@@ -1,9 +1,16 @@
 package dev.walshy.sfmetrics.charts;
 
-import dev.walshy.sfmetrics.MetricsModule;
-import org.bstats.bukkit.Metrics;
+import org.bstats.bukkit.Metrics.SimplePie;
 
-public class MetricsVersionChart extends Metrics.SimplePie {
+import dev.walshy.sfmetrics.MetricsModule;
+
+/**
+ * This {@link SimplePie} shows us the currently installed version of this {@link MetricsModule}.
+ * 
+ * @author Walshy
+ *
+ */
+public class MetricsVersionChart extends SimplePie {
 
     public MetricsVersionChart() {
         super("metrics_version", () -> MetricsModule.VERSION);

--- a/src/main/java/dev/walshy/sfmetrics/charts/NewServersChart.java
+++ b/src/main/java/dev/walshy/sfmetrics/charts/NewServersChart.java
@@ -31,12 +31,12 @@ public class NewServersChart extends SingleLineChart implements VersionDependent
         if (branch == SlimefunBranch.DEVELOPMENT) {
             return build >= 600;
         }
-
-        if (branch == SlimefunBranch.STABLE) {
+        else if (branch == SlimefunBranch.STABLE) {
             return build >= 15;
         }
-
-        return false;
+        else {
+            return false;
+        }
     }
 
 }

--- a/src/main/java/dev/walshy/sfmetrics/charts/NewServersChart.java
+++ b/src/main/java/dev/walshy/sfmetrics/charts/NewServersChart.java
@@ -10,7 +10,11 @@ import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 
 /**
  * This single line graph shows the amount of {@link Server Servers} that installed
- * Slimefun for the very first time at that moment in time.
+ * Slimefun for the very first time.
+ * More precisely: A {@link Server} will be included if the current session is the session
+ * in which Slimefun was first installed.
+ * It will be reset once the {@link Server} has stopped or restarted.
+ * Subsequent sessions will then no longer be counted.
  * 
  * This allows us to better analyse the growth of this {@link Plugin} on a day-to-day basis.
  * 
@@ -20,7 +24,7 @@ import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 public class NewServersChart extends SingleLineChart implements VersionDependentChart {
 
     public NewServersChart() {
-        super("auto_updates", () -> {
+        super("new_servers", () -> {
             boolean newServer = SlimefunPlugin.isNewlyInstalled();
             return newServer ? 1 : 0;
         });

--- a/src/main/java/dev/walshy/sfmetrics/charts/NewServersChart.java
+++ b/src/main/java/dev/walshy/sfmetrics/charts/NewServersChart.java
@@ -1,0 +1,27 @@
+package dev.walshy.sfmetrics.charts;
+
+import org.bstats.bukkit.Metrics.SingleLineChart;
+import org.bukkit.Server;
+import org.bukkit.plugin.Plugin;
+
+import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
+
+/**
+ * This single line graph shows the amount of {@link Server Servers} that installed
+ * Slimefun for the very first time at that moment in time.
+ * 
+ * This allows us to better analyse the growth of this {@link Plugin} on a day-to-day basis.
+ * 
+ * @author TheBusyBiscuit
+ *
+ */
+public class NewServersChart extends SingleLineChart {
+
+    public NewServersChart() {
+        super("auto_updates", () -> {
+            boolean newServer = SlimefunPlugin.isNewlyInstalled();
+            return newServer ? 1 : 0;
+        });
+    }
+
+}

--- a/src/main/java/dev/walshy/sfmetrics/charts/NewServersChart.java
+++ b/src/main/java/dev/walshy/sfmetrics/charts/NewServersChart.java
@@ -4,6 +4,8 @@ import org.bstats.bukkit.Metrics.SingleLineChart;
 import org.bukkit.Server;
 import org.bukkit.plugin.Plugin;
 
+import dev.walshy.sfmetrics.VersionDependentChart;
+import io.github.thebusybiscuit.slimefun4.api.SlimefunBranch;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 
 /**
@@ -15,13 +17,26 @@ import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
  * @author TheBusyBiscuit
  *
  */
-public class NewServersChart extends SingleLineChart {
+public class NewServersChart extends SingleLineChart implements VersionDependentChart {
 
     public NewServersChart() {
         super("auto_updates", () -> {
             boolean newServer = SlimefunPlugin.isNewlyInstalled();
             return newServer ? 1 : 0;
         });
+    }
+
+    @Override
+    public boolean isCompatible(SlimefunBranch branch, int build) {
+        if (branch == SlimefunBranch.DEVELOPMENT) {
+            return build >= 600;
+        }
+
+        if (branch == SlimefunBranch.STABLE) {
+            return build >= 15;
+        }
+
+        return false;
     }
 
 }

--- a/src/main/java/dev/walshy/sfmetrics/charts/PlayerLanguageChart.java
+++ b/src/main/java/dev/walshy/sfmetrics/charts/PlayerLanguageChart.java
@@ -1,14 +1,22 @@
 package dev.walshy.sfmetrics.charts;
 
-import io.github.thebusybiscuit.slimefun4.core.services.localization.Language;
-import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.bstats.bukkit.Metrics.AdvancedPie;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
-import java.util.HashMap;
-import java.util.Map;
+import io.github.thebusybiscuit.slimefun4.core.services.localization.Language;
+import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 
+/**
+ * This {@link AdvancedPie} allows us to see what {@link Language Languages} are selected by
+ * {@link Player Players}.
+ * 
+ * @author TheBusyBiscuit
+ *
+ */
 public class PlayerLanguageChart extends AdvancedPie {
 
     public PlayerLanguageChart() {

--- a/src/main/java/dev/walshy/sfmetrics/charts/ResearchesEnabledChart.java
+++ b/src/main/java/dev/walshy/sfmetrics/charts/ResearchesEnabledChart.java
@@ -1,8 +1,18 @@
 package dev.walshy.sfmetrics.charts;
 
-import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import org.bstats.bukkit.Metrics.SimplePie;
+import org.bukkit.Server;
 
+import io.github.thebusybiscuit.slimefun4.core.researching.Research;
+import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
+
+/**
+ * This {@link SimplePie} allows us to see how many {@link Server Servers} have enabled or
+ * disabled {@link Research Researches}.
+ * 
+ * @author TheBusyBiscuit
+ *
+ */
 public class ResearchesEnabledChart extends SimplePie {
 
     public ResearchesEnabledChart() {

--- a/src/main/java/dev/walshy/sfmetrics/charts/ResourcePackChart.java
+++ b/src/main/java/dev/walshy/sfmetrics/charts/ResourcePackChart.java
@@ -1,8 +1,17 @@
 package dev.walshy.sfmetrics.charts;
 
-import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import org.bstats.bukkit.Metrics.SimplePie;
+import org.bukkit.Server;
 
+import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
+
+/**
+ * This {@link SimplePie} allows us to see what Slimefun Resource pack version is installed on
+ * {@link Server Servers} or whether they set up their resource packs.
+ * 
+ * @author TheBusyBiscuit
+ *
+ */
 public class ResourcePackChart extends SimplePie {
 
     public ResourcePackChart() {
@@ -11,9 +20,11 @@ public class ResourcePackChart extends SimplePie {
 
             if (version != null && version.startsWith("v")) {
                 return version + " (Official)";
-            } else if (SlimefunPlugin.getItemTextureService().isActive()) {
+            }
+            else if (SlimefunPlugin.getItemTextureService().isActive()) {
                 return "Custom / Modified";
-            } else {
+            }
+            else {
                 return "None";
             }
         });

--- a/src/main/java/dev/walshy/sfmetrics/charts/ServerLanguageChart.java
+++ b/src/main/java/dev/walshy/sfmetrics/charts/ServerLanguageChart.java
@@ -1,9 +1,18 @@
 package dev.walshy.sfmetrics.charts;
 
+import org.bstats.bukkit.Metrics.SimplePie;
+import org.bukkit.Server;
+
 import io.github.thebusybiscuit.slimefun4.core.services.localization.Language;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
-import org.bstats.bukkit.Metrics.SimplePie;
 
+/**
+ * This {@link SimplePie} allows us to see what {@link Server Servers} have configured as their
+ * default {@link Language}.
+ * 
+ * @author TheBusyBiscuit
+ *
+ */
 public class ServerLanguageChart extends SimplePie {
 
     public ServerLanguageChart() {

--- a/src/main/java/dev/walshy/sfmetrics/charts/ServerSizeChart.java
+++ b/src/main/java/dev/walshy/sfmetrics/charts/ServerSizeChart.java
@@ -2,38 +2,53 @@ package dev.walshy.sfmetrics.charts;
 
 import org.bstats.bukkit.Metrics.SimplePie;
 import org.bukkit.Bukkit;
+import org.bukkit.Server;
 
+/**
+ * This {@link SimplePie} allows us to see how big a {@link Server} is (player-wise).
+ * 
+ * @author TheBusyBiscuit
+ *
+ */
 public class ServerSizeChart extends SimplePie {
 
     public ServerSizeChart() {
         super("server_size", () -> {
             int players = Bukkit.getOnlinePlayers().size();
 
-            if (players < 10) {
-                return "0-10";
+            if (players < 5) {
+                return "0-5";
+            }
+
+            if (players < 15) {
+                return "5-15";
             }
 
             if (players < 25) {
-                return "10-25";
+                return "15-25";
             }
 
             if (players < 50) {
                 return "25-50";
             }
 
+            if (players < 75) {
+                return "50-75";
+            }
+
             if (players < 100) {
-                return "50-100";
+                return "75-100";
+            }
+
+            if (players < 150) {
+                return "100-150";
             }
 
             if (players < 200) {
-                return "100-200";
+                return "150-200";
             }
 
-            if (players < 300) {
-                return "200-300";
-            }
-
-            return "300+";
+            return "200+";
         });
     }
 

--- a/src/main/java/dev/walshy/sfmetrics/charts/ServerSizeChart.java
+++ b/src/main/java/dev/walshy/sfmetrics/charts/ServerSizeChart.java
@@ -19,36 +19,30 @@ public class ServerSizeChart extends SimplePie {
             if (players < 5) {
                 return "0-5";
             }
-
-            if (players < 15) {
+            else if (players < 15) {
                 return "5-15";
             }
-
-            if (players < 25) {
+            else if (players < 25) {
                 return "15-25";
             }
-
-            if (players < 50) {
+            else if (players < 50) {
                 return "25-50";
             }
-
-            if (players < 75) {
+            else if (players < 75) {
                 return "50-75";
             }
-
-            if (players < 100) {
+            else if (players < 100) {
                 return "75-100";
             }
-
-            if (players < 150) {
+            else if (players < 150) {
                 return "100-150";
             }
-
-            if (players < 200) {
+            else if (players < 200) {
                 return "150-200";
             }
-
-            return "200+";
+            else {
+                return "200+";
+            }
         });
     }
 

--- a/src/main/java/dev/walshy/sfmetrics/charts/SlimefunVersionChart.java
+++ b/src/main/java/dev/walshy/sfmetrics/charts/SlimefunVersionChart.java
@@ -1,11 +1,23 @@
 package dev.walshy.sfmetrics.charts;
 
-import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
-import org.bstats.bukkit.Metrics;
-
 import java.util.HashMap;
 import java.util.Map;
 
+import org.bstats.bukkit.Metrics;
+import org.bstats.bukkit.Metrics.DrilldownPie;
+import org.bukkit.Server;
+
+import io.github.thebusybiscuit.slimefun4.api.SlimefunBranch;
+import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
+
+/**
+ * This {@link DrilldownPie} allows us to see what version of Slimefun is installed on
+ * {@link Server Servers}. It is seperated by their {@link SlimefunBranch Branch}, so we
+ * can also see what branches are preferred.
+ * 
+ * @author TheBusyBiscuit
+ *
+ */
 public class SlimefunVersionChart extends Metrics.DrilldownPie {
 
     public SlimefunVersionChart() {


### PR DESCRIPTION
This is an aggregation of #3 and #4 with the addition of the functional interface `VersionDependentChart` which allows us to disable charts for versions that we don't support or simply don't have that feature yet.