### PR TITLE
Stability improvements + Armor Tick rates

### DIFF
--- a/src/main/java/dev/walshy/sfmetrics/SlimefunMetricsChart.java
+++ b/src/main/java/dev/walshy/sfmetrics/SlimefunMetricsChart.java
@@ -1,0 +1,32 @@
+package dev.walshy.sfmetrics;
+
+import org.bstats.bukkit.Metrics.CustomChart;
+
+import com.google.gson.JsonObject;
+
+/**
+ * This represents a {@link CustomChart} from Slimefun.
+ * 
+ * @author TheBusyBiscuit
+ *
+ */
+public interface SlimefunMetricsChart {
+
+    /**
+     * This returns the chart ids chart
+     * 
+     * @return The chart name
+     */
+    String getName();
+
+    /**
+     * This returns the chart data, it is used for initial testing purposes
+     * 
+     * @throws Exception
+     *             This is used for testing purposes, any {@link Exception} should be caught
+     * 
+     * @return The data of this chart
+     */
+    JsonObject getDataSample() throws Exception;
+
+}

--- a/src/main/java/dev/walshy/sfmetrics/VersionDependentChart.java
+++ b/src/main/java/dev/walshy/sfmetrics/VersionDependentChart.java
@@ -1,19 +1,27 @@
 package dev.walshy.sfmetrics;
 
-import org.bstats.bukkit.Metrics.CustomChart;
-
 import io.github.thebusybiscuit.slimefun4.api.SlimefunBranch;
 
 /**
- * This {@link FunctionalInterface} marks a {@link CustomChart} as dependent on specific
+ * This interface marks a {@link SlimefunMetricsChart} as dependent on specific
  * versions of Slimefun.
  * 
  * @author TheBusyBiscuit
  *
  */
-@FunctionalInterface
-public interface VersionDependentChart {
+public interface VersionDependentChart extends SlimefunMetricsChart {
 
+    /**
+     * This method checks if this chart is compatible with the given installation of
+     * Slimefun.
+     * 
+     * @param branch
+     *            The {@link SlimefunBranch} of this version
+     * @param build
+     *            The build number of this version
+     * 
+     * @return Whether this chart is compatible
+     */
     boolean isCompatible(SlimefunBranch branch, int build);
 
 }

--- a/src/main/java/dev/walshy/sfmetrics/charts/AddonsChart.java
+++ b/src/main/java/dev/walshy/sfmetrics/charts/AddonsChart.java
@@ -7,6 +7,9 @@ import org.bstats.bukkit.Metrics.AdvancedPie;
 import org.bukkit.Server;
 import org.bukkit.plugin.Plugin;
 
+import com.google.gson.JsonObject;
+
+import dev.walshy.sfmetrics.SlimefunMetricsChart;
 import io.github.thebusybiscuit.slimefun4.api.SlimefunAddon;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 
@@ -19,7 +22,7 @@ import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
  * @author TheBusyBiscuit
  *
  */
-public class AddonsChart extends AdvancedPie {
+public class AddonsChart extends AdvancedPie implements SlimefunMetricsChart {
 
     public AddonsChart() {
         super("installed_addons", () -> {
@@ -33,6 +36,16 @@ public class AddonsChart extends AdvancedPie {
 
             return addons;
         });
+    }
+
+    @Override
+    public String getName() {
+        return "Addons";
+    }
+
+    @Override
+    public JsonObject getDataSample() throws Exception {
+        return getChartData();
     }
 
 }

--- a/src/main/java/dev/walshy/sfmetrics/charts/AutoUpdaterChart.java
+++ b/src/main/java/dev/walshy/sfmetrics/charts/AutoUpdaterChart.java
@@ -3,6 +3,8 @@ package dev.walshy.sfmetrics.charts;
 import org.bstats.bukkit.Metrics.SimplePie;
 import org.bukkit.Server;
 
+import com.google.gson.JsonObject;
+
 import dev.walshy.sfmetrics.VersionDependentChart;
 import io.github.thebusybiscuit.slimefun4.api.SlimefunBranch;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
@@ -29,6 +31,16 @@ public class AutoUpdaterChart extends SimplePie implements VersionDependentChart
     public boolean isCompatible(SlimefunBranch branch, int build) {
         // Auto updates are only meaningful to us for official builds
         return branch.isOfficial();
+    }
+
+    @Override
+    public String getName() {
+        return "Auto Updates";
+    }
+
+    @Override
+    public JsonObject getDataSample() throws Exception {
+        return getChartData();
     }
 
 }

--- a/src/main/java/dev/walshy/sfmetrics/charts/CommandChart.java
+++ b/src/main/java/dev/walshy/sfmetrics/charts/CommandChart.java
@@ -5,6 +5,9 @@ import java.util.Map;
 
 import org.bstats.bukkit.Metrics.AdvancedPie;
 
+import com.google.gson.JsonObject;
+
+import dev.walshy.sfmetrics.SlimefunMetricsChart;
 import io.github.thebusybiscuit.slimefun4.core.commands.SubCommand;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 
@@ -16,7 +19,7 @@ import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
  * @author TheBusyBiscuit
  *
  */
-public class CommandChart extends AdvancedPie {
+public class CommandChart extends AdvancedPie implements SlimefunMetricsChart {
 
     public CommandChart() {
         super("commands_ran", () -> {
@@ -28,6 +31,16 @@ public class CommandChart extends AdvancedPie {
 
             return commands;
         });
+    }
+
+    @Override
+    public String getName() {
+        return "Commands";
+    }
+
+    @Override
+    public JsonObject getDataSample() throws Exception {
+        return getChartData();
     }
 
 }

--- a/src/main/java/dev/walshy/sfmetrics/charts/CompatibilityModeChart.java
+++ b/src/main/java/dev/walshy/sfmetrics/charts/CompatibilityModeChart.java
@@ -3,6 +3,9 @@ package dev.walshy.sfmetrics.charts;
 import org.bstats.bukkit.Metrics.SimplePie;
 import org.bukkit.Server;
 
+import com.google.gson.JsonObject;
+
+import dev.walshy.sfmetrics.SlimefunMetricsChart;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 
 /**
@@ -12,13 +15,23 @@ import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
  * @author TheBusyBiscuit
  *
  */
-public class CompatibilityModeChart extends SimplePie {
+public class CompatibilityModeChart extends SimplePie implements SlimefunMetricsChart {
 
     public CompatibilityModeChart() {
         super("compatibility_mode", () -> {
             boolean enabled = SlimefunPlugin.getRegistry().isBackwardsCompatible();
             return enabled ? "enabled" : "disabled";
         });
+    }
+
+    @Override
+    public String getName() {
+        return "Compatibility Mode";
+    }
+
+    @Override
+    public JsonObject getDataSample() throws Exception {
+        return getChartData();
     }
 
 }

--- a/src/main/java/dev/walshy/sfmetrics/charts/GuideLayoutChart.java
+++ b/src/main/java/dev/walshy/sfmetrics/charts/GuideLayoutChart.java
@@ -3,6 +3,9 @@ package dev.walshy.sfmetrics.charts;
 import org.bstats.bukkit.Metrics.SimplePie;
 import org.bukkit.Server;
 
+import com.google.gson.JsonObject;
+
+import dev.walshy.sfmetrics.SlimefunMetricsChart;
 import io.github.thebusybiscuit.slimefun4.core.guide.SlimefunGuideLayout;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 
@@ -13,7 +16,7 @@ import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
  * @author TheBusyBiscuit
  *
  */
-public class GuideLayoutChart extends SimplePie {
+public class GuideLayoutChart extends SimplePie implements SlimefunMetricsChart {
 
     public GuideLayoutChart() {
         super("guide_layout", () -> {
@@ -21,6 +24,16 @@ public class GuideLayoutChart extends SimplePie {
 
             return book ? "Book" : "Chest GUI";
         });
+    }
+
+    @Override
+    public String getName() {
+        return "Slimefun Guide Layout";
+    }
+
+    @Override
+    public JsonObject getDataSample() throws Exception {
+        return getChartData();
     }
 
 }

--- a/src/main/java/dev/walshy/sfmetrics/charts/MetricsAutoUpdatesChart.java
+++ b/src/main/java/dev/walshy/sfmetrics/charts/MetricsAutoUpdatesChart.java
@@ -3,6 +3,8 @@ package dev.walshy.sfmetrics.charts;
 import org.bstats.bukkit.Metrics.SimplePie;
 import org.bukkit.Server;
 
+import com.google.gson.JsonObject;
+
 import dev.walshy.sfmetrics.MetricsModule;
 import dev.walshy.sfmetrics.VersionDependentChart;
 import io.github.thebusybiscuit.slimefun4.api.SlimefunBranch;
@@ -35,5 +37,15 @@ public class MetricsAutoUpdatesChart extends SimplePie implements VersionDepende
         else {
             return false;
         }
+    }
+
+    @Override
+    public String getName() {
+        return "Metrics Auto Updates";
+    }
+
+    @Override
+    public JsonObject getDataSample() throws Exception {
+        return getChartData();
     }
 }

--- a/src/main/java/dev/walshy/sfmetrics/charts/MetricsVersionChart.java
+++ b/src/main/java/dev/walshy/sfmetrics/charts/MetricsVersionChart.java
@@ -2,7 +2,10 @@ package dev.walshy.sfmetrics.charts;
 
 import org.bstats.bukkit.Metrics.SimplePie;
 
+import com.google.gson.JsonObject;
+
 import dev.walshy.sfmetrics.MetricsModule;
+import dev.walshy.sfmetrics.SlimefunMetricsChart;
 
 /**
  * This {@link SimplePie} shows us the currently installed version of this {@link MetricsModule}.
@@ -10,9 +13,19 @@ import dev.walshy.sfmetrics.MetricsModule;
  * @author Walshy
  *
  */
-public class MetricsVersionChart extends SimplePie {
+public class MetricsVersionChart extends SimplePie implements SlimefunMetricsChart {
 
     public MetricsVersionChart() {
         super("metrics_version", () -> MetricsModule.VERSION);
+    }
+
+    @Override
+    public String getName() {
+        return "Metrics Version";
+    }
+
+    @Override
+    public JsonObject getDataSample() throws Exception {
+        return getChartData();
     }
 }

--- a/src/main/java/dev/walshy/sfmetrics/charts/NewServersChart.java
+++ b/src/main/java/dev/walshy/sfmetrics/charts/NewServersChart.java
@@ -4,6 +4,8 @@ import org.bstats.bukkit.Metrics.SingleLineChart;
 import org.bukkit.Server;
 import org.bukkit.plugin.Plugin;
 
+import com.google.gson.JsonObject;
+
 import dev.walshy.sfmetrics.VersionDependentChart;
 import io.github.thebusybiscuit.slimefun4.api.SlimefunBranch;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
@@ -41,6 +43,16 @@ public class NewServersChart extends SingleLineChart implements VersionDependent
         else {
             return false;
         }
+    }
+
+    @Override
+    public String getName() {
+        return "New Servers";
+    }
+
+    @Override
+    public JsonObject getDataSample() throws Exception {
+        return getChartData();
     }
 
 }

--- a/src/main/java/dev/walshy/sfmetrics/charts/OnlinePlayersChart.java
+++ b/src/main/java/dev/walshy/sfmetrics/charts/OnlinePlayersChart.java
@@ -4,13 +4,17 @@ import org.bstats.bukkit.Metrics.SimplePie;
 import org.bukkit.Bukkit;
 import org.bukkit.Server;
 
+import com.google.gson.JsonObject;
+
+import dev.walshy.sfmetrics.SlimefunMetricsChart;
+
 /**
  * This {@link SimplePie} allows us to see how big a {@link Server} is (player-wise).
  * 
  * @author TheBusyBiscuit
  *
  */
-public class OnlinePlayersChart extends SimplePie {
+public class OnlinePlayersChart extends SimplePie implements SlimefunMetricsChart {
 
     public OnlinePlayersChart() {
         super("online_players", () -> {
@@ -44,6 +48,16 @@ public class OnlinePlayersChart extends SimplePie {
                 return "200+";
             }
         });
+    }
+
+    @Override
+    public String getName() {
+        return "Online Players";
+    }
+
+    @Override
+    public JsonObject getDataSample() throws Exception {
+        return getChartData();
     }
 
 }

--- a/src/main/java/dev/walshy/sfmetrics/charts/PlayerLanguageChart.java
+++ b/src/main/java/dev/walshy/sfmetrics/charts/PlayerLanguageChart.java
@@ -7,6 +7,9 @@ import org.bstats.bukkit.Metrics.AdvancedPie;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
+import com.google.gson.JsonObject;
+
+import dev.walshy.sfmetrics.SlimefunMetricsChart;
 import io.github.thebusybiscuit.slimefun4.core.services.localization.Language;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 
@@ -17,7 +20,7 @@ import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
  * @author TheBusyBiscuit
  *
  */
-public class PlayerLanguageChart extends AdvancedPie {
+public class PlayerLanguageChart extends AdvancedPie implements SlimefunMetricsChart {
 
     public PlayerLanguageChart() {
         super("player_languages", () -> {
@@ -33,6 +36,16 @@ public class PlayerLanguageChart extends AdvancedPie {
 
             return languages;
         });
+    }
+
+    @Override
+    public String getName() {
+        return "Player Languages";
+    }
+
+    @Override
+    public JsonObject getDataSample() throws Exception {
+        return getChartData();
     }
 
 }

--- a/src/main/java/dev/walshy/sfmetrics/charts/ResearchesEnabledChart.java
+++ b/src/main/java/dev/walshy/sfmetrics/charts/ResearchesEnabledChart.java
@@ -3,6 +3,9 @@ package dev.walshy.sfmetrics.charts;
 import org.bstats.bukkit.Metrics.SimplePie;
 import org.bukkit.Server;
 
+import com.google.gson.JsonObject;
+
+import dev.walshy.sfmetrics.SlimefunMetricsChart;
 import io.github.thebusybiscuit.slimefun4.core.researching.Research;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 
@@ -13,13 +16,23 @@ import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
  * @author TheBusyBiscuit
  *
  */
-public class ResearchesEnabledChart extends SimplePie {
+public class ResearchesEnabledChart extends SimplePie implements SlimefunMetricsChart {
 
     public ResearchesEnabledChart() {
         super("servers_with_researches_enabled", () -> {
             boolean enabled = SlimefunPlugin.getRegistry().isFreeCreativeResearchingEnabled();
             return enabled ? "enabled" : "disabled";
         });
+    }
+
+    @Override
+    public String getName() {
+        return "Researches enabled";
+    }
+
+    @Override
+    public JsonObject getDataSample() throws Exception {
+        return getChartData();
     }
 
 }

--- a/src/main/java/dev/walshy/sfmetrics/charts/ResourcePackChart.java
+++ b/src/main/java/dev/walshy/sfmetrics/charts/ResourcePackChart.java
@@ -3,6 +3,9 @@ package dev.walshy.sfmetrics.charts;
 import org.bstats.bukkit.Metrics.SimplePie;
 import org.bukkit.Server;
 
+import com.google.gson.JsonObject;
+
+import dev.walshy.sfmetrics.SlimefunMetricsChart;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 
 /**
@@ -12,7 +15,7 @@ import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
  * @author TheBusyBiscuit
  *
  */
-public class ResourcePackChart extends SimplePie {
+public class ResourcePackChart extends SimplePie implements SlimefunMetricsChart {
 
     public ResourcePackChart() {
         super("resourcepack", () -> {
@@ -28,6 +31,16 @@ public class ResourcePackChart extends SimplePie {
                 return "None";
             }
         });
+    }
+
+    @Override
+    public String getName() {
+        return "Resource Packs";
+    }
+
+    @Override
+    public JsonObject getDataSample() throws Exception {
+        return getChartData();
     }
 
 }

--- a/src/main/java/dev/walshy/sfmetrics/charts/ServerLanguageChart.java
+++ b/src/main/java/dev/walshy/sfmetrics/charts/ServerLanguageChart.java
@@ -3,6 +3,9 @@ package dev.walshy.sfmetrics.charts;
 import org.bstats.bukkit.Metrics.SimplePie;
 import org.bukkit.Server;
 
+import com.google.gson.JsonObject;
+
+import dev.walshy.sfmetrics.SlimefunMetricsChart;
 import io.github.thebusybiscuit.slimefun4.core.services.localization.Language;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 
@@ -13,7 +16,7 @@ import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
  * @author TheBusyBiscuit
  *
  */
-public class ServerLanguageChart extends SimplePie {
+public class ServerLanguageChart extends SimplePie implements SlimefunMetricsChart {
 
     public ServerLanguageChart() {
         super("language", () -> {
@@ -21,6 +24,16 @@ public class ServerLanguageChart extends SimplePie {
             boolean supported = SlimefunPlugin.getLocalization().isLanguageLoaded(language.getId());
             return supported ? language.getId() : "Unsupported Language";
         });
+    }
+
+    @Override
+    public String getName() {
+        return "Server Language";
+    }
+
+    @Override
+    public JsonObject getDataSample() throws Exception {
+        return getChartData();
     }
 
 }

--- a/src/main/java/dev/walshy/sfmetrics/charts/SlimefunVersionChart.java
+++ b/src/main/java/dev/walshy/sfmetrics/charts/SlimefunVersionChart.java
@@ -3,10 +3,12 @@ package dev.walshy.sfmetrics.charts;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.bstats.bukkit.Metrics;
 import org.bstats.bukkit.Metrics.DrilldownPie;
 import org.bukkit.Server;
 
+import com.google.gson.JsonObject;
+
+import dev.walshy.sfmetrics.SlimefunMetricsChart;
 import io.github.thebusybiscuit.slimefun4.api.SlimefunBranch;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 
@@ -18,7 +20,7 @@ import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
  * @author TheBusyBiscuit
  *
  */
-public class SlimefunVersionChart extends Metrics.DrilldownPie {
+public class SlimefunVersionChart extends DrilldownPie implements SlimefunMetricsChart {
 
     public SlimefunVersionChart() {
         super("slimefun_version", () -> {
@@ -30,5 +32,15 @@ public class SlimefunVersionChart extends Metrics.DrilldownPie {
 
             return outerMap;
         });
+    }
+
+    @Override
+    public String getName() {
+        return "Slimefun Version";
+    }
+
+    @Override
+    public JsonObject getDataSample() throws Exception {
+        return getChartData();
     }
 }

--- a/src/main/java/dev/walshy/sfmetrics/charts/TickRateChart.java
+++ b/src/main/java/dev/walshy/sfmetrics/charts/TickRateChart.java
@@ -23,6 +23,7 @@ public class TickRateChart extends DrilldownPie implements SlimefunMetricsChart 
         super("tick_rate", () -> {
             Map<String, Map<String, Integer>> map = new HashMap<>();
             int tickRate = SlimefunPlugin.getTickerTask().getTickRate();
+            int armorTickRate = SlimefunPlugin.getCfg().getInt("options.armor-update-interval");
             int cargoDelay = SlimefunPlugin.getCfg().getInt("networks.cargo-ticker-delay");
 
             // For normal blocks the tick-rate will be taken literal
@@ -35,7 +36,12 @@ public class TickRateChart extends DrilldownPie implements SlimefunMetricsChart 
             Map<String, Integer> cargo = new HashMap<>();
             cargo.put(String.valueOf(tickRate + tickRate * cargoDelay), 1);
 
+            // The armor tick rate
+            Map<String, Integer> armor = new HashMap<>();
+            armor.put(String.valueOf(armorTickRate), 1);
+
             map.put("Standard", normal);
+            map.put("Slimefun Armor / Radiation", armor);
             map.put("Cargo networks", cargo);
 
             return map;

--- a/src/main/java/dev/walshy/sfmetrics/charts/TickRateChart.java
+++ b/src/main/java/dev/walshy/sfmetrics/charts/TickRateChart.java
@@ -5,6 +5,9 @@ import java.util.Map;
 
 import org.bstats.bukkit.Metrics.DrilldownPie;
 
+import com.google.gson.JsonObject;
+
+import dev.walshy.sfmetrics.SlimefunMetricsChart;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 
 /**
@@ -14,7 +17,7 @@ import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
  * @author TheBusyBiscuit
  *
  */
-public class TickRateChart extends DrilldownPie {
+public class TickRateChart extends DrilldownPie implements SlimefunMetricsChart {
 
     public TickRateChart() {
         super("tick_rate", () -> {
@@ -37,6 +40,16 @@ public class TickRateChart extends DrilldownPie {
 
             return map;
         });
+    }
+
+    @Override
+    public String getName() {
+        return "Tick Rates";
+    }
+
+    @Override
+    public JsonObject getDataSample() throws Exception {
+        return getChartData();
     }
 
 }


### PR DESCRIPTION
This Pull Request adds "Armor tick rates" to the Tick Rate chart.

But most importantly it brings many stability improvements:
* Data sending at runtime can now be tested when creating the charts initially
* Charts now have a name
* Disabling auto updates can lead to future problems and therefore we should tell users that an exception was caused by this setting