### PR TITLE
Added Error-Reports Chart

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,13 +29,13 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.16.1-R0.1-SNAPSHOT</version>
+            <version>1.16.3-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.github.TheBusyBiscuit</groupId>
             <artifactId>Slimefun4</artifactId>
-            <version>9c006f6897</version>
+            <version>RC-16</version>
             <scope>provided</scope>
         </dependency>
 
@@ -43,6 +43,7 @@
             <groupId>org.bstats</groupId>
             <artifactId>bstats-bukkit</artifactId>
             <version>1.7</version>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
 

--- a/src/main/java/dev/walshy/sfmetrics/MetricsModule.java
+++ b/src/main/java/dev/walshy/sfmetrics/MetricsModule.java
@@ -10,6 +10,7 @@ import dev.walshy.sfmetrics.charts.AddonsChart;
 import dev.walshy.sfmetrics.charts.AutoUpdaterChart;
 import dev.walshy.sfmetrics.charts.CommandChart;
 import dev.walshy.sfmetrics.charts.CompatibilityModeChart;
+import dev.walshy.sfmetrics.charts.ErrorReportsChart;
 import dev.walshy.sfmetrics.charts.GuideLayoutChart;
 import dev.walshy.sfmetrics.charts.MetricsAutoUpdatesChart;
 import dev.walshy.sfmetrics.charts.MetricsVersionChart;
@@ -59,6 +60,7 @@ public class MetricsModule {
         addChart(metrics, NewServersChart::new);
         addChart(metrics, MetricsAutoUpdatesChart::new);
         addChart(metrics, TickRateChart::new);
+        addChart(metrics, ErrorReportsChart::new);
 
         SlimefunPlugin.instance().getLogger().log(Level.INFO, "Now running MetricsModule build #{0}", VERSION);
         SlimefunPlugin.instance().getLogger().log(Level.INFO, "with a total of {0}/{1} chart(s)!", new Object[] { enabledCharts, totalCharts });

--- a/src/main/java/dev/walshy/sfmetrics/charts/ErrorReportsChart.java
+++ b/src/main/java/dev/walshy/sfmetrics/charts/ErrorReportsChart.java
@@ -1,0 +1,54 @@
+package dev.walshy.sfmetrics.charts;
+
+import org.bstats.bukkit.Metrics.SingleLineChart;
+
+import com.google.gson.JsonObject;
+
+import dev.walshy.sfmetrics.VersionDependentChart;
+import io.github.thebusybiscuit.slimefun4.api.ErrorReport;
+import io.github.thebusybiscuit.slimefun4.api.SlimefunBranch;
+
+/**
+ * This single line graph shows the amount of {@link ErrorReport ErrorReports} generated.
+ * 
+ * @author TheBusyBiscuit
+ *
+ */
+public class ErrorReportsChart extends SingleLineChart implements VersionDependentChart {
+
+    // This needs to be static due to it being passed to the super constructor
+    private static int lastValue = 0;
+
+    public ErrorReportsChart() {
+        super("error_reports", () -> {
+            int currentValue = ErrorReport.count();
+            int amount = currentValue - lastValue;
+            lastValue = currentValue;
+            return amount;
+        });
+    }
+
+    @Override
+    public boolean isCompatible(SlimefunBranch branch, int build) {
+        if (branch == SlimefunBranch.DEVELOPMENT) {
+            return build >= 638;
+        }
+        else if (branch == SlimefunBranch.STABLE) {
+            return build >= 16;
+        }
+        else {
+            return false;
+        }
+    }
+
+    @Override
+    public String getName() {
+        return "Error-Reports";
+    }
+
+    @Override
+    public JsonObject getDataSample() throws Exception {
+        return getChartData();
+    }
+
+}


### PR DESCRIPTION
I recently added a counter to ErrorReport.java, this will allow us to get the amount of error reports generated on a timely basis.
This will help allow us to identify faulty builds or suspect when something might be wrong.

This also counts error-reports from addons so we can assume if we broke something that way too.