### PR TITLE
Add disabled items chart

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -25,6 +25,7 @@ jobs:
     - name: Set up JDK 1.8
       uses: actions/setup-java@master
       with:
-        java-version: 1.8
+        java-version: 8
+        distribution: 'adopt'
     - name: Build with Maven
       run: mvn package --file pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>com.github.TheBusyBiscuit</groupId>
             <artifactId>Slimefun4</artifactId>
-            <version>RC-18</version>
+            <version>RC-22</version>
             <scope>provided</scope>
         </dependency>
 
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>org.bstats</groupId>
             <artifactId>bstats-bukkit</artifactId>
-            <version>2.1.0</version>
+            <version>2.2.1</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/dev/walshy/sfmetrics/MetricsModule.java
+++ b/src/main/java/dev/walshy/sfmetrics/MetricsModule.java
@@ -5,6 +5,7 @@ import java.util.logging.Level;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import dev.walshy.sfmetrics.charts.DisabledItemsChart;
 import org.bstats.bukkit.Metrics;
 import org.bstats.charts.CustomChart;
 
@@ -65,6 +66,7 @@ public class MetricsModule {
         addChart(metrics, ErrorReportsChart::new);
         addChart(metrics, IntegrationsChart::new);
         addChart(metrics, CSCoreLibChart::new);
+        addChart(metrics, DisabledItemsChart::new);
 
         SlimefunPlugin.instance().getLogger().log(Level.INFO, "Now running MetricsModule build #{0}", VERSION);
         SlimefunPlugin.instance().getLogger().log(Level.INFO, "with a total of {0}/{1} chart(s)!", new Object[] { enabledCharts, totalCharts });

--- a/src/main/java/dev/walshy/sfmetrics/charts/DisabledItemsChart.java
+++ b/src/main/java/dev/walshy/sfmetrics/charts/DisabledItemsChart.java
@@ -1,0 +1,60 @@
+package dev.walshy.sfmetrics.charts;
+
+import dev.walshy.sfmetrics.SlimefunMetricsChart;
+import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
+import org.bstats.charts.AdvancedPie;
+import org.bstats.json.JsonObjectBuilder;
+import org.bukkit.Server;
+
+import javax.annotation.Nonnull;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This {@link AdvancedPie} shows us what {@link SlimefunItem Items} have been disabled on the
+ * {@link Server}.
+ * <p>
+ * This allows us to see what Items are very unpopular and may be considered for rework/removal.
+ *
+ * @author TheBusyBiscuit
+ */
+public class DisabledItemsChart extends AdvancedPie implements SlimefunMetricsChart {
+
+    private static Map<String, Integer> disabledItems;
+
+    public DisabledItemsChart() {
+        super("disabled_items", () -> {
+            if (disabledItems != null) {
+                return disabledItems;
+            } else {
+                fetchItems();
+                return Collections.emptyMap();
+            }
+        });
+    }
+
+    @Nonnull
+    @Override
+    public String getName() {
+        return "Disabled Items";
+    }
+
+    @Nonnull
+    @Override
+    public JsonObjectBuilder.JsonObject getDataSample() throws Exception {
+        return getChartData();
+    }
+
+    private static void fetchItems() {
+        new Thread(() -> {
+            disabledItems = new HashMap<>();
+            for (SlimefunItem item : SlimefunPlugin.getRegistry().getAllSlimefunItems()) {
+                if (item.getAddon().equals(SlimefunPlugin.instance()) && item.isDisabled()) {
+                    disabledItems.put(item.getId(), 1);
+                }
+            }
+        }).start();
+    }
+}

--- a/src/main/java/dev/walshy/sfmetrics/charts/DisabledItemsChart.java
+++ b/src/main/java/dev/walshy/sfmetrics/charts/DisabledItemsChart.java
@@ -18,7 +18,7 @@ import java.util.Map;
  * <p>
  * This allows us to see what Items are very unpopular and may be considered for rework/removal.
  *
- * @author TheBusyBiscuit
+ * @author Walshy
  */
 public class DisabledItemsChart extends AdvancedPie implements SlimefunMetricsChart {
 

--- a/src/main/java/dev/walshy/sfmetrics/charts/DisabledItemsChart.java
+++ b/src/main/java/dev/walshy/sfmetrics/charts/DisabledItemsChart.java
@@ -55,6 +55,6 @@ public class DisabledItemsChart extends AdvancedPie implements SlimefunMetricsCh
                     disabledItems.put(item.getId(), 1);
                 }
             }
-        }).start();
+        }, "Slimefun - disabled items fetcher").start();
     }
 }


### PR DESCRIPTION
Added a disabled items chart so that we can see the hated items. This will only do official items.

I put the fetching of these items in another thread as I feel it may take a little bit and this runs on the server thread. So instead on the first fetch it will return an empty map and then trigger the new thread. On the next fetch (and all after) it will then return the cached disabled items.

Let me know if you don't think this needs another thread